### PR TITLE
Added reference to the `FIXME`-tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # task-list package
 
-This package parses TODO comments and displays them in a list, and navigates to them on selection.
+This package parses `TODO` and `FIXME` comments, displays them in a list, and navigates to them on selection.
 
 Activate with `ctrl-option-t`
 
 ####Sample Comment:
 
-`// TODO: Test Comment`
+```
+  // TODO: Test comment
+  // FIXME: Test comment, too
+```
 
 ####Preview:
 


### PR DESCRIPTION
When i installed the package the first time, i was not sure which tags are supported. Therefore i added a reference to the 2nd supported `FIXME`-tag (after sneaking into the source).
