### PR TITLE
Match something like  `todo:test`

### DIFF
--- a/lib/task-list-view.coffee
+++ b/lib/task-list-view.coffee
@@ -14,9 +14,9 @@ class TaskListView extends SelectListView
     if editor
       ebuffer = editor.buffer
       if ebuffer
-        matcher = /TODO ?: (.*)|FIXME ?: (.*)/g
-        todoFinder = /TODO ?: (.*)/
-        fixmeFinder = /FIXME ?: (.*)/
+        matcher = /TODO ?: ?(.*)|FIXME ?: ?(.*)/gi
+        todoFinder = /TODO ?: ?(.*)/i
+        fixmeFinder = /FIXME ?: ?(.*)/i
         todos = []
         if ebuffer.cachedText
           if ebuffer.cachedText.match(matcher)


### PR DESCRIPTION
1. todo:test
2. todo: test
3. TODO:test
4. TODO: test

Current only the 4th form is recognized. By using this patch, all the 4 forms are recognized now.