### PR TITLE
Support `TODO ....` and `TODO - ....` styles, in addition to `TODO: ....`

### DIFF
--- a/lib/task-list-view.coffee
+++ b/lib/task-list-view.coffee
@@ -3,12 +3,12 @@
 module.exports =
 
 class TaskListView extends SelectListView
+
   initialize: ->
     super
     @addClass('overlay from-top task-list')
     return atom.workspaceView.command 'task-list:toggle', =>
       return @.toggle()
-
 
   attach: ->
     editor = atom.workspaceView.getActivePaneItem()
@@ -33,6 +33,7 @@ class TaskListView extends SelectListView
           @setItems([{message: 'No Tasks Found' , type: ''}])
         atom.workspaceView.append(this)
         @focusFilterEditor()
+        
   viewForItem: (item) ->
     if item.type == 'TODO'
       markerClass = 'task-status status text-success'
@@ -45,6 +46,7 @@ class TaskListView extends SelectListView
         @div class: 'pull-right', =>
           @div class: markerClass , item.type
         @div class: 'task-item', item.message
+        
   confirmed: (item) ->
     editor = atom.workspaceView.getActivePaneItem()
     ebuffer = editor.buffer

--- a/lib/task-list-view.coffee
+++ b/lib/task-list-view.coffee
@@ -9,22 +9,23 @@ class TaskListView extends SelectListView
     return atom.workspaceView.command 'task-list:toggle', =>
       return @.toggle()
 
+
   attach: ->
     editor = atom.workspaceView.getActivePaneItem()
     if editor
       ebuffer = editor.buffer
       if ebuffer
-        matcher = /TODO ?: ?(.*)|FIXME ?: ?(.*)/gi
-        todoFinder = /TODO ?: ?(.*)/i
-        fixmeFinder = /FIXME ?: ?(.*)/i
+        matcher = /(TODO\s*(:|-|\s)\s*(.*))|(FIXME\s*(:|-|\s)\s*(.*))/gi
+        todoFinder = /TODO\s*(:|-|\s)\s*(.*)/i
+        fixmeFinder = /FIXME\s*(:|-|\s)\s*(.*)/i
         todos = []
         if ebuffer.cachedText
           if ebuffer.cachedText.match(matcher)
             for match in ebuffer.cachedText.match(matcher)
               if todoFinder.exec(match)
-                todos.push({message: todoFinder.exec(match)[1], type: 'TODO'})
+                todos.push({message: todoFinder.exec(match)[2], type: 'TODO'})
               else
-                todos.push({message: fixmeFinder.exec(match)[1], type: 'FIXME'})
+                todos.push({message: fixmeFinder.exec(match)[2], type: 'FIXME'})
             @setItems(todos)
           else
             @setItems([{message: 'No Tasks Found' , type: ''}])

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "task-list",
   "main": "./lib/task-list",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "Display and navigate to TODO: style comments",
   "activationEvents": [

--- a/spec/fixtures/script.js
+++ b/spec/fixtures/script.js
@@ -1,1 +1,23 @@
 // TODO: Test Comment
+// FIXME :Test Comment 2
+// TODO:Test Comment 3
+// TODO : Test Comment 4
+// TODO				:	Test Comment 5
+// TODO - Test Comment 6
+// FIXME-Test Comment 7
+// TODO    -   Test Comment 8
+// TODO Test Comment 9
+// TODO       Test Comment 10
+// before TODO: Test Comment 11
+/*
+TODO: block comment
+*/
+var map { // TODO task at end of line
+TO_DO: "not a comment", // FIX-ME: this example (and the one following it) fail in the sense that when you reomve the underscore they are parsed as to do items
+FIX_ME : "still not a comment"
+}
+var str = "// TO DO in a string"; // this also fails
+/*
+TODO: block comment line 1
+TODO: block comment line 2
+*/

--- a/spec/task-list-view-spec.coffee
+++ b/spec/task-list-view-spec.coffee
@@ -13,13 +13,33 @@ describe "TaskListView", ->
 
       taskView = new TaskListView()
       taskView.attach()
-
       expect(
         atom.workspaceView.find(
           '.task-list ol.list-group li.selected .task-item'
         ).text()).toBe("Test Comment")
 
-    it "displays No Tasks Found if there are not comments", ->
+    it "finds various forms of TODO", ->
+
+      taskView = new TaskListView()
+      taskView.attach()
+      tasks = atom.workspaceView.find('.task-list ol.list-group .task-item')
+      expect(tasks[0].innerText).toBe("Test Comment");
+      expect(tasks[1].innerText).toBe("Test Comment 2");
+      expect(tasks[2].innerText).toBe("Test Comment 3");
+      expect(tasks[3].innerText).toBe("Test Comment 4");
+      expect(tasks[4].innerText).toBe("Test Comment 5");
+      expect(tasks[5].innerText).toBe("Test Comment 6");
+      expect(tasks[6].innerText).toBe("Test Comment 7");
+      expect(tasks[7].innerText).toBe("Test Comment 8");
+      expect(tasks[8].innerText).toBe("Test Comment 9");
+      expect(tasks[9].innerText).toBe("Test Comment 10");
+      expect(tasks[10].innerText).toBe("Test Comment 11");
+      expect(tasks[11].innerText).toBe("block comment");
+      expect(tasks[12].innerText).toBe("task at end of line");
+      expect(tasks[13].innerText).toBe("block comment line 1");
+      expect(tasks[14].innerText).toBe("block comment line 2");
+
+    it "displays No Tasks Found if there are no TODO comments", ->
 
       atom.workspaceView.getActivePaneItem().setText("")
       taskView = new TaskListView()


### PR DESCRIPTION
This patch modifies the TODO-matching (and FIXME-matching) regexp such that:
1. Arbitrary horizontal whitespace, not just single space, is allowed before and after the colon
2. The dash character (`-`) can be used as the TODO "delimiter", in addition to a colon, e.g., `TODO - something to do`
3. Just whitespace can be used as the TODO delimiter, e.g. `TODO something to do`

In addition, a test case is added in order to:
1. Test for the new functionality described above.
2. Test the existing functionality a little more robustly.
